### PR TITLE
Use Terraform Modules to simplify rule deployment

### DIFF
--- a/terraform/custom_rule_module/README.md
+++ b/terraform/custom_rule_module/README.md
@@ -1,0 +1,7 @@
+Custom AWS Config Rule
+======================
+
+This module creates a custom AWS Config rule, which uses a lambda to execute a specified handler
+which is implemented in the Java application.
+
+The module will create a Lambda, IAM Policy, and an AWS Config Rule.

--- a/terraform/custom_rule_module/main.tf
+++ b/terraform/custom_rule_module/main.tf
@@ -1,0 +1,75 @@
+resource "aws_iam_role" "lambda_role" {
+  name = "${var.name}-lambda-iam-role-for-rules"
+
+  path = "/service-role/"
+
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": "sts:AssumeRole",
+      "Effect": "Allow",
+      "Principal": {
+        "Service": "lambda.amazonaws.com"
+      }
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_iam_role_policy_attachment" "role_additional_policy" {
+  for_each = toset(var.additional_policies)
+  policy_arn = each.key
+  role = aws_iam_role.lambda_role.name
+}
+
+resource "aws_iam_role_policy_attachment" "role_lambda_policy" {
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+  role = aws_iam_role.lambda_role.name
+}
+
+resource "aws_iam_role_policy_attachment" "role_config_policy" {
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSConfigRulesExecutionRole"
+  role = aws_iam_role.lambda_role.name
+}
+
+resource "aws_lambda_function" "lambda_function" {
+  s3_bucket = var.s3.bucket
+  s3_key = var.s3.key
+  function_name = "${var.name}-lambda-function"
+  handler = var.handler
+
+  runtime = "java8"
+
+  role = aws_iam_role.lambda_role.arn
+
+  memory_size = 512
+  timeout = 15
+}
+
+resource "aws_lambda_permission" "lambda_permission" {
+  action        = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.lambda_function.arn
+  principal     = "config.amazonaws.com"
+  statement_id  = "AllowExecutionFromConfig"
+}
+
+resource "aws_config_config_rule" "config_rule" {
+  name = "${var.name}-config_rule"
+  source {
+    owner = "CUSTOM_LAMBDA"
+    source_identifier = aws_lambda_function.lambda_function.arn
+    source_detail {
+      message_type = "ScheduledNotification"
+      maximum_execution_frequency = "TwentyFour_Hours"
+    }
+    source_detail {
+      message_type = "ConfigurationItemChangeNotification"
+    }
+  }
+  scope {
+    compliance_resource_types = var.resource_types
+  }
+}

--- a/terraform/custom_rule_module/variables.tf
+++ b/terraform/custom_rule_module/variables.tf
@@ -1,0 +1,32 @@
+variable "name" {
+  description = "A short name for this rule"
+  type        = "string"
+}
+
+variable "s3" {
+  description = "S3 configuration for the lambda jar"
+  type        = "map"
+
+  default = {
+    bucket = "none"
+    key    = "none"
+  }
+}
+
+variable "handler" {
+  description = "Fully qualified name describing the class or method to use as the Lambda handler"
+  type        = "string"
+  default     = "com.scottlogic.compliance.dynamodb.SecureTransportCheck"
+}
+
+variable "resource_types" {
+  description = "A list of resource types which should trigger the config rule"
+  type        = "list"
+  default     = ["AWS::IAM::User"]
+}
+
+variable additional_policies {
+  description = "A list of policy ARNs to attach to the role used by the lambda"
+  type        = "list"
+  default     = []
+}

--- a/terraform/dynamodb_secure_transport_check.tf
+++ b/terraform/dynamodb_secure_transport_check.tf
@@ -1,73 +1,12 @@
-resource "aws_iam_role" "lambda_iam_test" {
-  name = "lambda_iam_role_for_rules_test"
+module "config_rule" {
+  source = "./custom_rule_module"
 
-  path = "/service-role/"
-
-  assume_role_policy = <<EOF
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Action": "sts:AssumeRole",
-      "Effect": "Allow",
-      "Principal": {
-        "Service": "lambda.amazonaws.com"
-      }
-    }
-  ]
-}
-EOF
-}
-
-resource "aws_iam_role_policy_attachment" "role_iam_policy" {
-  policy_arn = "arn:aws:iam::aws:policy/IAMReadOnlyAccess"
-  role = "${aws_iam_role.lambda_iam_test.name}"
-}
-
-resource "aws_iam_role_policy_attachment" "role_lambda_policy" {
-  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
-  role = "${aws_iam_role.lambda_iam_test.name}"
-}
-
-resource "aws_iam_role_policy_attachment" "role_config_policy" {
-  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSConfigRulesExecutionRole"
-  role = "${aws_iam_role.lambda_iam_test.name}"
-}
-
-resource "aws_lambda_function" "lambda_test_1" {
-  s3_bucket = "${aws_s3_bucket.s3.id}"
-  s3_key = "${aws_s3_bucket_object.rules_jar.key}"
-  function_name = "lambda_rules_test_1"
+  name = "dynamodb-secure-transport-check"
+  additional_policies = ["arn:aws:iam::aws:policy/IAMReadOnlyAccess"]
+  s3 = {
+    bucket = aws_s3_bucket.s3.id
+    key    = aws_s3_bucket_object.rules_jar.key
+  }
   handler = "com.scottlogic.compliance.dynamodb.SecureTransportCheck"
-
-  runtime = "java8"
-
-  role = "${aws_iam_role.lambda_iam_test.arn}"
-
-  memory_size = 512
-  timeout = 15
-}
-resource "aws_lambda_permission" "lambda_iam_test_permission_1" {
-  action        = "lambda:InvokeFunction"
-  function_name = "${aws_lambda_function.lambda_test_1.arn}"
-  principal     = "config.amazonaws.com"
-  statement_id  = "AllowExecutionFromConfig"
-}
-
-resource "aws_config_config_rule" "config_rule_1" {
-  name = "config_rule_test_1"
-  source {
-    owner = "CUSTOM_LAMBDA"
-    source_identifier = "${aws_lambda_function.lambda_test_1.arn}"
-    source_detail {
-      message_type = "ScheduledNotification"
-      maximum_execution_frequency = "TwentyFour_Hours"
-    }
-    source_detail {
-      message_type = "ConfigurationItemChangeNotification"
-    }
-  }
-  scope {
-    compliance_resource_types = ["AWS::IAM::User"]
-  }
+  resource_types = ["AWS::IAM::User"]
 }


### PR DESCRIPTION
Pull out the common AWS components used in deploying a 'rule' to a terraform module.

The module is then called from the terraform root directory with a handful of variables to set:
 - handler fqn and jar location for Lambda
 - additional IAM permissions required for the Lambda execution
 - resource types to trigger the rule on